### PR TITLE
feature - Improve method tag parsing

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Tag/MethodTag.php
+++ b/src/Barryvdh/Reflection/DocBlock/Tag/MethodTag.php
@@ -76,7 +76,15 @@ class MethodTag extends ReturnTag
                 )?
                 # Return type
                 (?:
-                    ([\w\|_\\\\]+)
+                    (
+                        (?:[\w\|_\\\\]*\$this[\w\|_\\\\]*)
+                        |
+                        (?:
+                            (?:[\w\|_\\\\]+)
+                            # array notation
+                            (?:\[\])*
+                        )*
+                    )
                     \s+
                 )?
                 # Legacy method name (not captured)


### PR DESCRIPTION
This is an update based on the original repository, I just cherry-picked
some code.

https://github.com/phpDocumentor/ReflectionDocBlock/blob/master/src/DocBlock/Tags/Method.php

This includes:
- https://github.com/phpDocumentor/ReflectionDocBlock/commit/e9454d844db9d8fd2f276a2069647c3c4fb15085
- https://github.com/phpDocumentor/ReflectionDocBlock/commit/e9454d844db9d8fd2f276a2069647c3c4fb15085

### Why we need this

The changes are related to issue https://github.com/barryvdh/laravel-ide-helper/issues/739 where two methods are both in the docblock of the `File` class and added as actual functions in the class. 

Normally, duplicates are filtered, but in this case that failed because the method signatures were not parsed properly.

These are the signatures of the method tags:

```
@method static \Symfony\Component\Finder\SplFileInfo[] files(string $directory, bool $hidden = false)
@method static \Symfony\Component\Finder\SplFileInfo[] allFiles(string $directory, bool $hidden = false)
```

You can see the return type includes array brackets. This was something that was not supported before.