### PR TITLE
Fix annotation error about typed array like array<mixed> or array<int…

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
+++ b/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
@@ -151,6 +151,10 @@ class Collection extends \ArrayObject
             return '';
         }
 
+        if (substr($type, 0, 6) === 'array<' && substr($type, -1) === '>') {
+            return $type;
+        }
+
         if ($this->isTypeAnArray($type)) {
             return $this->expand(substr($type, 0, -2)) . self::OPERATOR_ARRAY;
         }


### PR DESCRIPTION
Description:

If a function in \FooNameSpace\BarClass has a typed array annotation array like array\<mixed\>, 
after running `php artisan ide-helper:generate`, the function annotation in `_ide_helper.php` is '\FooNameSpace\BarClass\array\<mixed\>', expect is array\<mixed\>.