### PR TITLE
Support parsing SuppressWarnings tags in doc block

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Tag.php
+++ b/src/Barryvdh/Reflection/DocBlock/Tag.php
@@ -95,7 +95,9 @@ class Tag implements \Reflector
         'var'
             => '\Barryvdh\Reflection\DocBlock\Tag\VarTag',
         'version'
-            => '\Barryvdh\Reflection\DocBlock\Tag\VersionTag'
+            => '\Barryvdh\Reflection\DocBlock\Tag\VersionTag',
+        'SuppressWarnings'
+            => '\Barryvdh\Reflection\DocBlock\Tag\SuppressWarningsTag'
     );
 
     /**

--- a/src/Barryvdh/Reflection/DocBlock/Tag/SuppressWarningsTag.php
+++ b/src/Barryvdh/Reflection/DocBlock/Tag/SuppressWarningsTag.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @author    Andrew Smith <espadav8@gmail.com>
+ * @copyright 2010-2011 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace Barryvdh\Reflection\DocBlock\Tag;
+
+use Barryvdh\Reflection\DocBlock\Tag;
+
+/**
+ * Reflection class for a @SuppressWarnings tag in a Docblock.
+ *
+ * @author  Andrew Smith <espadav8@gmail.com>
+ * @license http://www.opensource.org/licenses/mit-license.php MIT
+ * @link    http://phpdoc.org
+ */
+class SuppressWarningsTag extends Tag
+{
+    public function __toString()
+    {
+        return "@{$this->getName()}{$this->getContent()}";
+    }
+}

--- a/tests/Barryvdh/Reflection/DocBlock/Tag/SuppressWarningsTagTest.php
+++ b/tests/Barryvdh/Reflection/DocBlock/Tag/SuppressWarningsTagTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * phpDocumentor SuppressWarnings Tag Test
+ *
+ * PHP version 5.3
+ *
+ * @author    Andrew Smith <espadav8@gmail.com>
+ * @copyright 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace Barryvdh\Reflection\DocBlock\Tag;
+
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for \Barryvdh\Reflection\DocBlock\Tag\SuppressWarningsTag
+ *
+ * @author    Andrew Smith <espadav8@gmail.com>
+ * @copyright 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+class SuppressWarningsTagTest extends TestCase
+{
+    /**
+     * Test that the \Barryvdh\Reflection\DocBlock\Tag\SuppressWarningsTag can
+     * understand the @SuppressWarnings doc block.
+     *
+     * @param string $type
+     * @param string $content
+     * @param string $exType
+     * @param string $exVariable
+     * @param string $exDescription
+     *
+     * @covers \Barryvdh\Reflection\DocBlock\Tag\SuppressWarningsTag
+     * @dataProvider provideDataForConstuctor
+     *
+     * @return void
+     */
+    public function testConstructorParesInputsIntoCorrectFields(
+        $type,
+        $content,
+        $description
+    ) {
+        $tag = new SuppressWarningsTag($type, $content);
+
+        $this->assertEquals($type, $tag->getName());
+        $this->assertEquals($description, $tag->getDescription());
+    }
+
+    /**
+     * Data provider for testConstructorParesInputsIntoCorrectFields
+     *
+     * @return array
+     */
+    public function provideDataForConstuctor()
+    {
+        // $type, $content, $description
+        return array(
+            array(
+                'SuppressWarnings',
+                'SuppressWarnings(PHPMD)',
+                'SuppressWarnings(PHPMD)',
+            ),
+            array(
+                'SuppressWarnings',
+                'SuppressWarnings(PHPMD.TooManyMethods)',
+                'SuppressWarnings(PHPMD.TooManyMethods)',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
This should address is issue in the `laravel-ide-helper` package that breaks `@SuppressWarnings` tags in the doc blocks (https://github.com/barryvdh/laravel-ide-helper/issues/666).