### PR TITLE
Add support for parsing method tag with return type using generics

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Tag/MethodTag.php
+++ b/src/Barryvdh/Reflection/DocBlock/Tag/MethodTag.php
@@ -84,6 +84,7 @@ class MethodTag extends ReturnTag
                             # array notation
                             (?:\[\])*
                         )*
+                        (?:<[^>]+>)?
                     )
                     \s+
                 )?

--- a/tests/Barryvdh/Reflection/DocBlock/Tag/MethodTagTest.php
+++ b/tests/Barryvdh/Reflection/DocBlock/Tag/MethodTagTest.php
@@ -142,6 +142,10 @@ class MethodTagTest extends TestCase
             array(
                 'static static foo()',
                 true, 'foo', 'static', true, 0, ''
+            ),
+            array(
+                'static \App\Custom\Collection<int, static> foo()',
+                true, 'foo', '\App\Custom\Collection<int, static>', true, 0, ''
             )
         );
     }


### PR DESCRIPTION
When using the ide-helper package with `use_generics_annotations` config enabled, I ran into the issue that when using a custom Collection, the `all` and `get` methods are added every time the models command is run, even if they are in the docblock already. This PR solves this issue by correctly parsing method tags with generics syntax.