### PR TITLE
fix: for laravel-ide-helper's 1505 issue;

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Tag/ParamTag.php
+++ b/src/Barryvdh/Reflection/DocBlock/Tag/ParamTag.php
@@ -49,7 +49,7 @@ class ParamTag extends ReturnTag
         $parts = preg_split(
             '/(\s+)/Su',
             $this->description,
-            3,
+            4,
             PREG_SPLIT_DELIM_CAPTURE
         );
 

--- a/tests/Barryvdh/Reflection/DocBlock/Tag/ParamTagTest.php
+++ b/tests/Barryvdh/Reflection/DocBlock/Tag/ParamTagTest.php
@@ -114,6 +114,46 @@ class ParamTagTest extends TestCase
                 array('int'),
                 '$bob',
                 "Type on a new line"
+            ),
+            array(
+                'param',
+                "array \$arrayNoGenericsDescription Some text",
+                'array',
+                array('array'),
+                '$arrayNoGenericsDescription',
+                "Some text"
+            ),
+            array(
+                'param',
+                "array<int, string> \$arrayGenericsNoDescription",
+                'array<int, string>',
+                array('array<int, string>'),
+                '$arrayGenericsNoDescription',
+                ""
+            ),
+            array(
+                'param',
+                "array<int,string> \$arrayGenericsNoSpaceDescription Description goes here",
+                'array<int,string>',
+                array('array<int,string>'),
+                '$arrayGenericsNoSpaceDescription',
+                "Description goes here"
+            ),
+            array(
+                'param',
+                "array<int, string> \$arrayGenericsDescription Description goes here",
+                'array<int, string>',
+                array('array<int, string>'),
+                '$arrayGenericsDescription',
+                "Description goes here"
+            ),
+            array(
+                'param',
+                "array<int, string> \$arrayGenericsDescription Description multiline\n goes\n here",
+                'array<int, string>',
+                array('array<int, string>'),
+                '$arrayGenericsDescription',
+                "Description multiline\n goes\n here"
             )
         );
     }


### PR DESCRIPTION
### The problem
Param's generic type and description cancel out one another which lose description in the end.

---
This should fix https://github.com/barryvdh/laravel-ide-helper/issues/1505 