### PR TITLE
Support nested generics and closures type hint

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
+++ b/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
@@ -145,9 +145,9 @@ class Collection extends \ArrayObject
                 $type_parts[] = $curr_type;
                 $curr_type = '';
             } else {
-                if ($char === '<') {
+                if ($char === '<' || $char === '(') {
                     $nest_level++;
-                } else if ($char === '>') {
+                } else if ($char === '>' || $char === ')') {
                     $nest_level--;
                 }
 
@@ -186,6 +186,10 @@ class Collection extends \ArrayObject
         }
 
         if (substr($type, 0, 6) === 'array<' && substr($type, -1) === '>') {
+            return $type;
+        }
+
+        if($type[0] === '(') {
             return $type;
         }
 

--- a/tests/Barryvdh/Reflection/DocBlock/Tag/ParamTagTest.php
+++ b/tests/Barryvdh/Reflection/DocBlock/Tag/ParamTagTest.php
@@ -114,7 +114,75 @@ class ParamTagTest extends TestCase
                 array('int'),
                 '$bob',
                 "Type on a new line"
-            )
+            ),
+
+            // generic array
+            array(
+                'param',
+                'array<int, string> $names',
+                'array<int, string>',
+                array('array<int, string>'),
+                '$names',
+                ''
+            ),
+
+            // nested generics
+            array(
+                'param',
+                'array<int, array<string, mixed>> $arrays',
+                'array<int, array<string, mixed>>',
+                array('array<int, array<string, mixed>>'),
+                '$arrays',
+                ''
+            ),
+
+            // closure
+            array(
+                'param',
+                '(\Closure(int, string): bool) $callback',
+                '(\Closure(int, string): bool)',
+                array('(\Closure(int, string): bool)'),
+                '$callback',
+                ''
+            ),
+
+            // generic array in closure
+            array(
+                'param',
+                '(\Closure(array<int, string>): bool) $callback',
+                '(\Closure(array<int, string>): bool)',
+                array('(\Closure(array<int, string>): bool)'),
+                '$callback',
+                ''
+            ),
+
+            // union types in closure
+            array(
+                'param',
+                '(\Closure(int|string): bool)|bool $callback',
+                '(\Closure(int|string): bool)|bool',
+                array('(\Closure(int|string): bool)', 'bool'),
+                '$callback',
+                ''
+            ),
+
+            // example from Laravel Framework - Eloquent Builder)
+            array(
+                'param',
+                'array<array-key, array|(\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string>|string  $relations',
+                'array<array-key, array|(\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string>|string',
+                array('array<array-key, array|(\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string>', 'string'),
+                '$relations',
+                ''
+            ),
+            array(
+                'param',
+                '(\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string|null  $callback',
+                '(\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string|null',
+                array('(\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)', 'string', 'null'),
+                '$callback',
+                ''
+            ),
         );
     }
 }


### PR DESCRIPTION
Fixed an issue where an incorrect parsing result was returned when the type declared in `@param` was a nested generic type or closure.

A simple solution was already in place for generic types, but it did not support cases where multiple whitespaces were included due to nesting. Closures also use whitespace when defined accurately, but this was not supported either.

I fixed this issue by implementing a simple parser.

## Issues this pull request resolves
* barryvdh/laravel-ide-helper#1505
  * However, there is a test equivalent to *xfail* written to address this issue, which must be removed.
* Incorrect helper files being output when using Laravel IDE Helper with the latest Laravel Framework.
  * Even complex annotations, such as those improved in laravel/framework#52729, are output accurately.

## Testing overview

I not only added many test cases, but also tested Laravel IDE Helper with this patch applied. The results changed as follows:

### Resolving barrydh/laravel-ide-helper#1505

```
1) Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ArrayCastsWithComment\Test::test
Failed asserting that two strings are identical.

Snapshots can be updated by passing `-d --update-snapshots` through PHPUnit's CLI arguments.
--- Expected
+++ Actual
@@ @@
  * @property string $cast_to_bool
  * @property string $cast_to_boolean
  * @property string $cast_to_object
- * @property array $cast_to_array
- * @property array $cast_to_json
- * @property \Illuminate\Support\Collection $cast_to_collection
  * @property string $cast_to_date
  * @property string $cast_to_datetime
  * @property string $cast_to_date_serialization

/tmp/barryvdh/laravel-ide-helper/tests/SnapshotPhpDriver.php:24
/tmp/barryvdh/laravel-ide-helper/vendor/spatie/phpunit-snapshot-assertions/src/Snapshot.php:55
/tmp/barryvdh/laravel-ide-helper/vendor/spatie/phpunit-snapshot-assertions/src/MatchesSnapshots.php:199
/tmp/barryvdh/laravel-ide-helper/vendor/spatie/phpunit-snapshot-assertions/src/MatchesSnapshots.php:57
/tmp/barryvdh/laravel-ide-helper/tests/Console/ModelsCommand/AbstractModelsCommand.php:58
/tmp/barryvdh/laravel-ide-helper/tests/Console/ModelsCommand/ArrayCastsWithComment/Test.php:26
```

Failed the xfail-equivalent test. The issue appears to have been fixed.

### Fixed multiple issues with Laravel IDE Helper

```
2) Barryvdh\LaravelIdeHelper\Tests\MethodTest::testEloquentBuilderOutput
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 '/**
  * Set the relationships that should be eager loaded.
  *
- * @param string|array $relations
- * @param string|\Closure|null $callback
+ * @param array<array-key, array|(\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string>|string $relations
+ * @param (\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)|string|null $callback
  * @return \Illuminate\Database\Eloquent\Builder|static
  * @static
  */'

/tmp/barryvdh/laravel-ide-helper/barryvdh-laravel-ide-helper/tests/MethodTest.php:76
```

This is a test that recently failed due to a change in the Laravel Framework. The patch changed the reason for the failure.

For reference, without this patch, the failure reason will be [as follows](https://github.com/barryvdh/laravel-ide-helper/actions/runs/11356569456/job/31587989197):

```
1) Barryvdh\LaravelIdeHelper\Tests\MethodTest::testEloquentBuilderOutput
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 '/**
  * Set the relationships that should be eager loaded.
  *
- * @param string|array $relations
- * @param string|\Closure|null $callback
+ * @param \Illuminate\Database\Eloquent\array<array-key, array|(\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>):  mixed)|string>|string  $relations
+ * @param \Illuminate\Database\Eloquent\(\Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>):  mixed)|string|null  $callback
  * @return \Illuminate\Database\Eloquent\Builder|static 
  * @static 
  */'

/home/runner/work/laravel-ide-helper/laravel-ide-helper/tests/MethodTest.php:76
```

Before the patch, the output was obviously broken. As already shown, this will now be accurate.