### PR TITLE
Fixed incorrect parsing of return types for generics and closures

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Tag/MethodTag.php
+++ b/src/Barryvdh/Reflection/DocBlock/Tag/MethodTag.php
@@ -80,10 +80,12 @@ class MethodTag extends ReturnTag
                         (?:[\w\|_\\\\]*\$this[\w\|_\\\\]*)
                         |
                         (?:
-                            (?:[\w\|_\\\\]+)
+                            (?:[\w\|_\\\\]+(?:<[\s\S]*>)?)
                             # array notation
                             (?:\[\])*
                         )*
+                        |
+                        (?:\([\s\S]*\))?
                     )
                     \s+
                 )?

--- a/tests/Barryvdh/Reflection/DocBlock/Tag/MethodTagTest.php
+++ b/tests/Barryvdh/Reflection/DocBlock/Tag/MethodTagTest.php
@@ -142,7 +142,25 @@ class MethodTagTest extends TestCase
             array(
                 'static static foo()',
                 true, 'foo', 'static', true, 0, ''
-            )
+            ),
+
+            // generic array
+            array(
+                'array<int, string> foo()',
+                true, 'foo', 'array<int, string>', false, 0, ''
+            ),
+
+            // nested generics
+            array(
+                'array<int, array<string, mixed>> foo()',
+                true, 'foo', 'array<int, array<string, mixed>>', false, 0, ''
+            ),
+
+            // closure
+            array(
+                '(\Closure(int, string): bool) foo()',
+                true, 'foo', '(\Closure(int, string): bool)', false, 0, ''
+            ),
         );
     }
 }


### PR DESCRIPTION
Related to #17, fixes a parsing issue with return types defined in the `@method` tag.

Only some characters such as alphabets and the namespace separator `\` can be used in return types, but currently `<...>` and `(...)` are not supported, so:

* Generic syntax including whitespace
  e.g. `array<int, string>`

* Syntax that requires grouping such as closures
  e.g. `(\Closure(int, string): bool)`

These cannot be parsed correctly.

No error occurs, but execution continues without the parsing result, which causes problems in various subsequent processes.

This has been fixed by expanding the regular expression for parsing.

## Note

In addition to the test cases included in this pull request, I have verified that applying this fix to the Laravel IDE Helper resolves issue barryvdh/laravel-ide-helper#1599.
