### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock.php
+++ b/src/Barryvdh/Reflection/DocBlock.php
@@ -71,8 +71,8 @@ class DocBlock implements \Reflector
      */
     public function __construct(
         $docblock,
-        Context $context = null,
-        Location $location = null
+        ?Context $context = null,
+        ?Location $location = null
     ) {
         if (is_object($docblock)) {
             if (!method_exists($docblock, 'getDocComment')) {

--- a/src/Barryvdh/Reflection/DocBlock/Description.php
+++ b/src/Barryvdh/Reflection/DocBlock/Description.php
@@ -38,7 +38,7 @@ class Description implements \Reflector
      * @param string   $content  The description's conetnts.
      * @param DocBlock $docblock The DocBlock which this description belongs to.
      */
-    public function __construct($content, DocBlock $docblock = null)
+    public function __construct($content, ?DocBlock $docblock = null)
     {
         $this->setContent($content)->setDocBlock($docblock);
     }
@@ -190,7 +190,7 @@ class Description implements \Reflector
      *
      * @return $this
      */
-    public function setDocBlock(DocBlock $docblock = null)
+    public function setDocBlock(?DocBlock $docblock = null)
     {
         $this->docblock = $docblock;
 

--- a/src/Barryvdh/Reflection/DocBlock/Tag.php
+++ b/src/Barryvdh/Reflection/DocBlock/Tag.php
@@ -113,8 +113,8 @@ class Tag implements \Reflector
      */
     final public static function createInstance(
         $tag_line,
-        DocBlock $docblock = null,
-        Location $location = null
+        ?DocBlock $docblock = null,
+        ?Location $location = null
     ) {
         if (!preg_match(
             '/^@(' . self::REGEX_TAGNAME . ')(?:\s*([^\s].*)|$)?/us',
@@ -194,8 +194,8 @@ class Tag implements \Reflector
     public function __construct(
         $name,
         $content,
-        DocBlock $docblock = null,
-        Location $location = null
+        ?DocBlock $docblock = null,
+        ?Location $location = null
     ) {
         $this
             ->setName($name)
@@ -323,7 +323,7 @@ class Tag implements \Reflector
      * 
      * @return $this
      */
-    public function setDocBlock(DocBlock $docblock = null)
+    public function setDocBlock(?DocBlock $docblock = null)
     {
         $this->docblock = $docblock;
 
@@ -347,7 +347,7 @@ class Tag implements \Reflector
      * 
      * @return $this
      */
-    public function setLocation(Location $location = null)
+    public function setLocation(?Location $location = null)
     {
         $this->location = $location;
 

--- a/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
+++ b/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
@@ -60,7 +60,7 @@ class Collection extends \ArrayObject
      */
     public function __construct(
         array $types = array(),
-        Context $context = null
+        ?Context $context = null
     ) {
         $this->context = null === $context ? new Context() : $context;
 


### PR DESCRIPTION
This PR removes implicitly nullable parameters because these result in deprecation warnings for PHP 8.4.

https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter