### PR TITLE
Added generics to Context

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Context.php
+++ b/src/Barryvdh/Reflection/DocBlock/Context.php
@@ -29,7 +29,10 @@ class Context
     
     /** @var string Name of the structural element, within the namespace. */
     protected $lsen = '';
-    
+
+    /** @var string[] List of generics */
+    protected $generics = array();
+
     /**
      * Cteates a new context.
      * @param string $namespace         The namespace where this DocBlock
@@ -42,13 +45,15 @@ class Context
     public function __construct(
         $namespace = '',
         array $namespace_aliases = array(),
-        $lsen = ''
+        $lsen = '',
+        array $generics = array()
     ) {
         if (!empty($namespace)) {
             $this->setNamespace($namespace);
         }
         $this->setNamespaceAliases($namespace_aliases);
         $this->setLSEN($lsen);
+        $this->setGenerics($generics);
     }
 
     /**
@@ -75,6 +80,16 @@ class Context
     public function getLSEN()
     {
         return $this->lsen;
+    }
+
+    /**
+     * Returns the list of generics.
+     *
+     * @return string[] List of generics
+     */
+    public function getGenerics()
+    {
+        return $this->generics;
     }
     
     /**
@@ -149,6 +164,19 @@ class Context
     public function setLSEN($lsen)
     {
         $this->lsen = (string)$lsen;
+        return $this;
+    }
+
+    /**
+     * Sets a new list of generics.
+     *
+     * @param string[] $generics The new list of generics.
+     *
+     * @return $this
+     */
+    public function setGenerics(array $generics)
+    {
+        $this->generics = $generics;
         return $this;
     }
 }

--- a/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
+++ b/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
@@ -71,7 +71,7 @@ class Collection extends \ArrayObject
         array $generics = array()
     ) {
         $this->context = null === $context ? new Context() : $context;
-        $this->generics = $generics;
+        $this->generics = array_merge($this->context->getGenerics(), $generics);
 
         foreach ($types as $type) {
             $this->add($type);

--- a/tests/Barryvdh/Reflection/DocBlock/Type/CollectionTest.php
+++ b/tests/Barryvdh/Reflection/DocBlock/Type/CollectionTest.php
@@ -157,7 +157,7 @@ class CollectionTest extends TestCase
     {
         $collection = new Collection(
             array(),
-            new Context('\My\Space', array('Alias' => '\My\Space\Aliasing')),
+            new Context('\My\Space', array('Alias' => '\My\Space\Aliasing'), '', array('TParent')),
             array('TValue')
         );
         $collection->add($fixture);
@@ -304,6 +304,7 @@ class CollectionTest extends TestCase
             array('TValue', array('TValue')),
             array('TValue[]', array('TValue[]')),
             array('TValue|DocBlock', array('TValue', $namespace . 'DocBlock')),
+            array('TParent', array('TParent')),
         );
     }
 }


### PR DESCRIPTION
This change will allow laravel-ide-helper to pass generics of class template to methods DocBlock using Context class.

Example class:
```php
/**
 * @template TModel of \Illuminate\Database\Eloquent\Model
 */
class Builder
{
    /**
     * Get the first record matching the attributes or instantiate it.
     *
     * @param  array  $attributes
     * @param  array  $values
     * @return TModel
     */
    public function firstOrNew(array $attributes = [], array $values = [])
    {}
}
```

In this way:
```php
$classDocBlock = new DocBlock($classDocBlockText);
$methodDocBlock = new DocBlock($methodDocBlockText, new Context($namespace, $classAliases, '', $classDocBlock->getGenerics()))
```