### PR TITLE
Fixed callable types parsing

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
+++ b/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
@@ -205,6 +205,11 @@ class Collection extends \ArrayObject
             return $type;
         }
 
+        // Check for callable types
+        if (preg_match('/\(.*?(?=\:)/', $type)) {
+            return $type;
+        }
+
         if($type[0] === '(') {
             return $type;
         }

--- a/tests/Barryvdh/Reflection/DocBlock/Type/CollectionTest.php
+++ b/tests/Barryvdh/Reflection/DocBlock/Type/CollectionTest.php
@@ -283,6 +283,14 @@ class CollectionTest extends TestCase
                 'iterable<string>',
                 array('iterable<string>')
             ),
+            array(
+                'callable',
+                array('callable')
+            ),
+            array(
+                'callable(int, string): int',
+                array('callable(int, string): int')
+            )
         );
     }
 


### PR DESCRIPTION
This fix avoids adding namespace to callable types, eg:
callable(int, string): int