### PR TITLE
Fixed parsing of string literals and array shapes

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Tag/ParamTag.php
+++ b/src/Barryvdh/Reflection/DocBlock/Tag/ParamTag.php
@@ -54,16 +54,15 @@ class ParamTag extends ReturnTag
         for($pos = 0, $stacks = []; $pos < strlen($rest); $pos++) {
             $char = $rest[$pos];
 
-            if($char === '<') {
+            if(in_array($char, ['<', '(', '[', '{'])) {
                 array_unshift($stacks, $char);
             }
-            if($char === '(') {
-                array_unshift($stacks, $char);
-            }
-            if($char === '>' && isset($stacks[0]) && $stacks[0] === '<') {
-                array_shift($stacks);
-            }
-            if($char === ')' && isset($stacks[0]) && $stacks[0] === '(') {
+            if(
+                ($char === '>' && isset($stacks[0]) && $stacks[0] === '<')
+                || ($char === ')' && isset($stacks[0]) && $stacks[0] === '(')
+                || ($char === ']' && isset($stacks[0]) && $stacks[0] === '[')
+                || ($char === '}' && isset($stacks[0]) && $stacks[0] === '{')
+            ) {
                 array_shift($stacks);
             }
 

--- a/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
+++ b/src/Barryvdh/Reflection/DocBlock/Type/Collection.php
@@ -161,9 +161,9 @@ class Collection extends \ArrayObject
                 $type_parts[] = $curr_type;
                 $curr_type = '';
             } else {
-                if ($char === '<' || $char === '(') {
+                if (in_array($char, ['<', '(', '[', '{'])) {
                     $nest_level++;
-                } else if ($char === '>' || $char === ')') {
+                } else if (in_array($char, ['>', ')', ']', '}'])) {
                     $nest_level--;
                 }
 
@@ -201,7 +201,8 @@ class Collection extends \ArrayObject
             return '';
         }
 
-        if (preg_match('/^[\w-]+<.*>$/', $type)) {
+        // Check for generics values and array shapes
+        if (preg_match('/^[\w-]+(<.+>|\[.+\]|{.+})$/', $type)) {
             return $type;
         }
 
@@ -211,6 +212,11 @@ class Collection extends \ArrayObject
         }
 
         if($type[0] === '(') {
+            return $type;
+        }
+
+        // Literal strings
+        if ($type[0] === '"' || $type[0] === "'") {
             return $type;
         }
 

--- a/tests/Barryvdh/Reflection/DocBlock/Tag/ParamTagTest.php
+++ b/tests/Barryvdh/Reflection/DocBlock/Tag/ParamTagTest.php
@@ -183,6 +183,24 @@ class ParamTagTest extends TestCase
                 '$callback',
                 ''
             ),
+
+            // array shapes
+            array(
+                'param',
+                'array{foo: string, bar: int} $array',
+                'array{foo: string, bar: int}',
+                array('array{foo: string, bar: int}'),
+                '$array',
+                ''
+            ),
+            array(
+                'param',
+                'MyArray[\'key\'] $value',
+                'MyArray[\'key\']',
+                array('MyArray[\'key\']'),
+                '$value',
+                ''
+            )
         );
     }
 }

--- a/tests/Barryvdh/Reflection/DocBlock/Tag/ReturnTagTest.php
+++ b/tests/Barryvdh/Reflection/DocBlock/Tag/ReturnTagTest.php
@@ -119,6 +119,13 @@ class ReturnTagTest extends TestCase
                 'array<int, string|bool>|string',
                 array('array<int, string|bool>', 'string'),
                 'Types of Bobs'
+            ),
+            array(
+                'return',
+                'MyArray[\'key\'] Type of Bobs',
+                'MyArray[\'key\']',
+                array('MyArray[\'key\']'),
+                'Type of Bobs'
             )
         );
     }

--- a/tests/Barryvdh/Reflection/DocBlock/Type/CollectionTest.php
+++ b/tests/Barryvdh/Reflection/DocBlock/Type/CollectionTest.php
@@ -240,6 +240,18 @@ class CollectionTest extends TestCase
                 array('array<int, string|array<int, bool>>', 'array<int, float>', 'string')
             ),
             array(
+                'array{ 0: string, 1: string|int }',
+                array('array{ 0: string, 1: string|int }')
+            ),
+            array(
+                "array{ 'key': string, 'value': string|int }",
+                array("array{ 'key': string, 'value': string|int }")
+            ),
+            array(
+                "MyArray['bar']",
+                array("MyArray['bar']")
+            ),
+            array(
                 'LinkDescriptor::setLink()',
                 array($namespace.'LinkDescriptor::setLink()')
             ),
@@ -290,6 +302,10 @@ class CollectionTest extends TestCase
             array(
                 'callable(int, string): int',
                 array('callable(int, string): int')
+            ),
+            array(
+                "'text'",
+                array("'text'")
             )
         );
     }


### PR DESCRIPTION
Examples of types that are fixed:
```
@param 'value1'|'value2'
@param array{ 0: string, 1: number }
@param MyArray['key']
```