### PR TITLE
trim_empty_docblock_whitespaces Trim whitespaces from phpdocs without…

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Tag.php
+++ b/src/Barryvdh/Reflection/DocBlock/Tag.php
@@ -409,6 +409,6 @@ class Tag implements \Reflector
      */
     public function __toString()
     {
-        return "@{$this->getName()} {$this->getContent()}";
+        return trim("@{$this->getName()} {$this->getContent()}");
     }
 }


### PR DESCRIPTION
To not fight code style tools, which want to have no trailing whitespaces after empty docblocks, those should be removed just like in the upstream repo: https://github.com/phpDocumentor/ReflectionDocBlock/blob/5.x/src/DocBlock/Tags/Formatter/PassthroughFormatter.php#L28