### PR TITLE
Remove Extra Blank Lines

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Serializer.php
+++ b/src/Barryvdh/Reflection/DocBlock/Serializer.php
@@ -207,7 +207,7 @@ class Serializer
         }
         $text = str_replace("\n", "\n{$indent} * ", $text);
 
-        $comment = "{$firstIndent}/**\n{$indent} * {$text}\n{$indent} *\n";
+        $comment = !empty($text)? "{$firstIndent}/**\n{$indent} * {$text}\n{$indent} *\n" : "{$firstIndent}/**\n";
 
         $tags = array_values($docblock->getTags());
 


### PR DESCRIPTION
Correcting an issue where there are two empty lines, first with an extra space, when there is no text to display on the first line.

Ran into this issue using the `ide-helper:models` command. Found [this post](https://github.com/barryvdh/laravel-ide-helper/issues/1682), and tracked it down to this being the culprit. Saw your comment here [about removing those two lines](https://github.com/barryvdh/laravel-ide-helper/pull/1523#pullrequestreview-1888206368) that was never addressed and figured I'd take care of it.

Produces the expected result:
```php
/**
 * @property int $id
 * @property int|null $user_id
```
instead of like before: 
```php
/**
 * 
 *
 * @property int $id
 * @property int|null $user_id
```