### PR TITLE
fix: Remove trailing spaces from empty docblock lines

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Serializer.php
+++ b/src/Barryvdh/Reflection/DocBlock/Serializer.php
@@ -206,6 +206,7 @@ class Serializer
             $text = wordwrap($text, $wrapLength);
         }
         $text = str_replace("\n", "\n{$indent} * ", $text);
+        $text = preg_replace('/^(\s*\*)[ \t]+$/m', '$1', $text);
 
         $comment = !empty($text)? "{$firstIndent}/**\n{$indent} * {$text}\n{$indent} *\n" : "{$firstIndent}/**\n";
 
@@ -220,6 +221,7 @@ class Serializer
                 $tagText = wordwrap($tagText, $wrapLength);
             }
             $tagText = str_replace("\n", "\n{$indent} * ", $tagText);
+            $tagText = preg_replace('/^(\s*\*)[ \t]+$/m', '$1', $tagText);
 
             $comment .= "{$indent} * {$tagText}\n";
 


### PR DESCRIPTION
## Problem

When a DocBlock has empty lines in its description text, the `Serializer` produces ` * ` (with a trailing space) for those lines instead of ` *`.

```php
/**
 * This model does something interesting.
 *    <-- trailing space here
 * It is an example of a model with documentation.
 *
 * @mixin IdeHelperMyModel
 */
```

This trips trailing-whitespace linters and requires a second clean-up pass.

## Root Cause

In `Serializer::getDocComment()`, each newline in the text is replaced via:

```php
$text = str_replace("\n", "\n{$indent} * ", $text);
```

When an empty line is present (consecutive newlines), the replacement produces `{indent} * ` -- ` * ` with a trailing space -- for that line.

## Fix

After each `str_replace`, apply a `preg_replace` to strip trailing horizontal whitespace from any line that is only ` *` followed by spaces:

```php
$text = preg_replace('/^(\s*\*)[ \t]+$/m', '$1', $text);
```

**Before:**
```
 * First line. 
 *     <-- trailing space
 * Second line.
```

**After:**
```
 * First line.
 *
 * Second line.
```

## Context

Raised by the maintainer (@barryvdh) in barryvdh/laravel-ide-helper#1768, where a workaround was applied downstream. Fixing here at the source is the right approach.
